### PR TITLE
Update grayprint.yaml

### DIFF
--- a/grayprint.yaml
+++ b/grayprint.yaml
@@ -327,7 +327,7 @@ layers:
         data: { source: osm, layer: roads }
         filter: { name: true, aeroway: false, tunnel: false, railway: false, not: { kind: rail } }
         highway:
-            filter: { kind: highway, $zoom: { min: 13 } }
+            filter: { kind: highway, $zoom: { min: 16 } }
             draw:
                 text:
                     font:


### PR DESCRIPTION
now must zoom closer to get highway labels.
